### PR TITLE
Test correctly

### DIFF
--- a/private/geoid-tests.rkt
+++ b/private/geoid-tests.rkt
@@ -423,7 +423,7 @@
        (check-true
         (or (equal? end (sentinel-geoid))
             (leaf-geoid? (- end (geoid-stride start)))))
-       (check-pred < start end)
+       (check < start end)
        (define count
          (if (equal? end (sentinel-geoid))
              (/ (+ (- (sub1 end) start) (geoid-stride start)) (geoid-stride start))


### PR DESCRIPTION
`check-pred` is for testing one value against a predicate.
Currently, it checks that `(< start)` is true (which will always be the
case), and `end` becomes a message, which is probably not
what's intended.

This PR switches to use `check` instead, which can be used to test
a binary relation on two values.