### PR TITLE
Add asserts to handle asin/acos type in Racket 9.2.

### DIFF
--- a/private/geodesy.rkt
+++ b/private/geodesy.rkt
@@ -354,9 +354,15 @@
 (: spherical-destination (-> Real Real Real Real (values Real Real)))
 (define (spherical-destination λ φ bearing distance)
   (define δ (/ distance earth-radius))
+  ;; NOTE: the argument to `asin` is mathematically in [-1, 1], but FP
+  ;; rounding can push it slightly outside, making `asin` return a
+  ;; complex number.  Clamp before calling `asin`.
   (define φ-dest
-    (asin (+ (* (sin φ) (cos δ))
-             (* (cos φ) (sin δ) (cos bearing)))))
+    (assert
+     (asin (max -1.0
+                (min 1.0 (+ (* (sin φ) (cos δ))
+                            (* (cos φ) (sin δ) (cos bearing))))))
+     real?))
   (define λ-dest
     (+ λ
        (atan (* (sin bearing) (sin δ) (cos φ))

--- a/private/geoid-tests.rkt
+++ b/private/geoid-tests.rkt
@@ -1262,6 +1262,22 @@
         (test-midway-point/spherical lat1 lon1 lat2 lon2)
         (test-intermediate-point/spherical lat1 lon1 lat2 lon2)))
 
+    (test-case "spherical-destination at pole returns real values"
+      ;; Starting at ~63.78°N heading due north for ~2915 km puts the
+      ;; destination at the North Pole.  The intermediate
+      ;; `(sin φ)·(cos δ) + (cos φ)·(sin δ)·(cos bearing)` rounds up to
+      ;; 1.0000000000000002 in IEEE double, so `asin` produces a
+      ;; complex result with a ~2e-8 imaginary part, which then
+      ;; propagates into the longitude computation.
+      (define λ 0.0)
+      (define φ 1.1132094410599405)
+      (define bearing 0.0)
+      (define distance 2915326.3166678636)
+      (define-values (λ-dest φ-dest)
+        (spherical-destination λ φ bearing distance))
+      (check-pred real? λ-dest "longitude should be real")
+      (check-pred real? φ-dest "latitude should be real"))
+
   ))
 
 (module+ test

--- a/private/geoid.rkt
+++ b/private/geoid.rkt
@@ -962,7 +962,7 @@
   (define cos-Θ (+ (* x1 x2) (* y1 y2) (* z1 z2)))
   ;; NOTE: small errors in the unit vector might bring the value below or
   ;; above 1, making `acos` return a complex number.
-  (* earth-radius (acos (max -1.0 (min 1.0 cos-Θ)))))
+  (* earth-radius (assert (acos (max -1.0 (min 1.0 cos-Θ))) flonum?)))
 
 (: distance-from-geoid (-> Integer (-> Integer Flonum)))
 (define (distance-from-geoid g1)
@@ -972,7 +972,7 @@
     (define cos-Θ (+ (* x1 x2) (* y1 y2) (* z1 z2)))
     ;; NOTE: small errors in the unit vector might bring the value below or
     ;; above 1, making `acos` return a complex number.
-    (* earth-radius (acos (max -1.0 (min 1.0 cos-Θ))))))
+    (* earth-radius (assert (acos (max -1.0 (min 1.0 cos-Θ))) flonum?))))
 
 
 ;;............................................................. The Cell ....

--- a/private/tiling.rkt
+++ b/private/tiling.rkt
@@ -1033,7 +1033,7 @@
   (define dot-product (+ (* s1x s2x) (* s1y s2y)))
   (if (or (zero? dot-product) (zero? s1len) (zero? s1len))
       0.0
-      (let ([angle (acos (min 1.0 (/ dot-product (* s1len s2len))))])
+      (let ([angle (assert (acos (min 1.0 (/ dot-product (* s1len s2len)))) flonum?)])
         (define cross-magnitude (- (* (- x1 x0) (- y2 y0))
                                    (* (- y1 y0) (- x2 x0))))
         (* angle (flsgn cross-magnitude)))))

--- a/private/waypoint-alignment.rkt
+++ b/private/waypoint-alignment.rkt
@@ -75,7 +75,7 @@
       (+ (* (flvector-ref s i) (flvector-ref t j))
          (* (flvector-ref s (+ i 1)) (flvector-ref t (+ j 1)))
          (* (flvector-ref s (+ i 2)) (flvector-ref t (+ j 2)))))
-    (acos (max -1.0 (min 1.0 dot))))
+    (assert (acos (max -1.0 (min 1.0 dot))) flonum?))
 
   (values n m unit-distance))
 


### PR DESCRIPTION
Racket 9.2 adjusts the type of `asin` and `acos` to be possibly
`Complex` for `Real` inputs. This is necessary for soundness,
but causes typecheck errors here. At least one of them actually
demonstrates a bug, which is added as a test case and fixed.